### PR TITLE
mask critical information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # express-logger
 Logger utils and middleware build upon winstonjs
 
+#### Test
+```bash
+$ npm test
+```
+
 #### configuration
 Logger generate human readable logs if configured with `process.env.LOG_FORMAT=pretty`, otherwise it will generate json.
+
+Winston rewriters will mask any critical information based in log `meta` key name, if key name (_case insensitive_) is one of `['password', 'pwd', 'auth', 'authorization', 'cfg']`, it's value will be replaced by `<REDACTED>`, No masking/redacting to any information if you have `NODE_ENV` set to `development`.
 
 
 #### middleware

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var CONSOLE_OPTIONS = {
 var options = {
     transports: [new winston.transports.Console(CONSOLE_OPTIONS)],
     exceptionHandlers: [new winston.transports.Console(CONSOLE_OPTIONS)],
-    rewriters: [rewriters.generalInfo, rewriters.xRequestId]
+    rewriters: process.env.NODE_ENV == "development" ? [rewriters.generalInfo, rewriters.xRequestId] : [rewriters.generalInfo, rewriters.xRequestId, rewriters.redactCriticalData]
 };
 
 global.logger = new winston.Logger(options);

--- a/middleware.js
+++ b/middleware.js
@@ -1,5 +1,5 @@
 var winston = require('winston');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var ewinston = require('express-winston');
 var prjctdir = require('cwd')();
 var pkg = require(prjctdir + '/package.json');
@@ -7,7 +7,7 @@ var pkg = require(prjctdir + '/package.json');
 function XRequestId() {
     return function(req, res, next) {
         if (!req.headers['x-request-id']) {
-            req.headers['x-request-id'] = req.id = uuid.v4();
+            req.headers['x-request-id'] = req.id = uuid();
         } else {
             req.headers['x-request-id'] = req.id = req.headers['x-request-id'] + "-" + pkg.name.toLowerCase();
         }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "exwml",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "express winston!",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -24,7 +24,12 @@
   "dependencies": {
     "cwd": "^0.10.0",
     "express-winston": "^2.0.0",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.0",
     "winston": "^2.2.0"
+  },
+  "devDependencies": {
+    "faker": "^3.1.0",
+    "mocha": "^3.1.2",
+    "should": "^11.1.1"
   }
 }

--- a/rewriters.js
+++ b/rewriters.js
@@ -1,6 +1,8 @@
 var prjctdir = require('cwd')();
 var pkg = require(prjctdir + '/package.json').name.toLowerCase();
 
+var SECERTS = ['password', 'pwd', 'auth', 'authorization', 'cfg'];
+
 module.exports = {
     /* Add NODE_ENV and the main package name */
     generalInfo: function(level, msg, meta) {
@@ -13,6 +15,22 @@ module.exports = {
         if (meta.req && meta.req.headers && meta.req.headers && meta.req.headers['x-request-id']) {
             meta['x-request-id'] = meta.req.headers['x-request-id'];
         }
+        return meta;
+    },
+    /* change any value of meta[key] if this key is on of #SECRET keys */
+    redactCriticalData: function(level, msg, meta) {
+        var _redact = function(obj) {
+            Object.keys(obj).forEach(function(key) {
+                if (meta[key] !== null && typeof obj[key] === 'object') {
+                    return _redact(obj[key]);
+                } else {
+                    if (SECERTS.includes(key.toLowerCase())) {
+                        obj[key] = '<REDACTED>';
+                    }
+                }
+            });
+        };
+        _redact(meta);
         return meta;
     }
 }

--- a/test/rewritersTest.js
+++ b/test/rewritersTest.js
@@ -1,0 +1,88 @@
+var should = require('should'),
+    faker = require('faker'),
+    rewriters = require('../rewriters');
+
+describe('Rewriters', function() {
+    describe('#redactCriticalData(msg, meta, level)', function() {
+        it('simple redact of top level secret information', function() {
+            var msg = faker.random.words(),
+                meta = {
+                    password: faker.internet.password(),
+                    pwd: faker.internet.password(),
+                    auth: new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    authorization: new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    Authorization: "Bearer " + new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    cfg: faker.random.number(),
+                    host: faker.internet.ip()
+                };
+            var redacted = rewriters.redactCriticalData('info', msg, meta);
+            redacted.password.should.be.eql('<REDACTED>');
+            redacted.pwd.should.be.eql('<REDACTED>');
+            redacted.auth.should.be.eql('<REDACTED>');
+            redacted.authorization.should.be.eql('<REDACTED>');
+            redacted.Authorization.should.be.eql('<REDACTED>');
+            redacted.cfg.should.be.eql('<REDACTED>');
+            redacted.host.should.not.eql('<REDACTED>');
+        });
+
+        it('redact nested secret information', function() {
+            var msg = faker.random.words(),
+                meta = {
+                    req: {
+                        query: {
+                            qs: {
+                                name: faker.internet.userName()
+                            },
+                            xm: {
+                                $: {
+                                    usr: faker.internet.userName(),
+                                    pwd: faker.internet.password(),
+                                    cfg: faker.random.number(),
+                                    data: faker.random.words()
+                                }
+                            }
+                        }
+                    },
+                    ind: {
+                        pdate: faker.date.past(),
+                        fdate: faker.date.future(),
+                    },
+                    auth: new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    authorization: new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    host: faker.internet.ip()
+                };
+            var redacted = rewriters.redactCriticalData('info', msg, meta);
+            redacted.req.query.qs.name.should.not.eql('<REDACTED>');
+            redacted.req.query.xm.$.usr.should.not.eql('<REDACTED>');
+            redacted.req.query.xm.$.pwd.should.be.eql('<REDACTED>');
+            redacted.req.query.xm.$.cfg.should.be.eql('<REDACTED>');
+            redacted.req.query.xm.$.data.should.not.eql('<REDACTED>');
+            redacted.ind.pdate.should.not.eql('<REDACTED>');
+            redacted.ind.fdate.should.not.eql('<REDACTED>');
+            redacted.auth.should.be.eql('<REDACTED>');
+            redacted.authorization.should.be.eql('<REDACTED>');
+            redacted.host.should.not.eql('<REDACTED>');
+        });
+
+        it('case insensitive secret keys', function() {
+            var msg = faker.random.words(),
+                meta = {
+                    passWord: faker.internet.password(),
+                    pwD: faker.internet.password(),
+                    Auth: new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    authoriZation: new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    Authorization: "Bearer " + new Buffer(faker.internet.userName + ":" + faker.internet.password).toString('base64'),
+                    CFG: faker.random.number(),
+                    host: faker.internet.ip()
+                };
+            var redacted = rewriters.redactCriticalData('info', msg, meta);
+            redacted.passWord.should.be.eql('<REDACTED>');
+            redacted.pwD.should.be.eql('<REDACTED>');
+            redacted.Auth.should.be.eql('<REDACTED>');
+            redacted.authoriZation.should.be.eql('<REDACTED>');
+            redacted.Authorization.should.be.eql('<REDACTED>');
+            redacted.CFG.should.be.eql('<REDACTED>');
+            redacted.host.should.not.eql('<REDACTED>');
+        });
+    });
+});


### PR DESCRIPTION
* Winston rewriters will mask any critical information based in log `meta` key name, if key name is one of `['password', 'pwd', 'auth', 'authorization', 'Authorization', 'cfg']`, it's value will be replaced by `<REDACTED>`, No masking/redacting to any information if you have `NODE_ENV` set to `development`.
* add Test for critical information rewriting